### PR TITLE
Correct typos and clarify actionables

### DIFF
--- a/learning-outcomes-novice.md
+++ b/learning-outcomes-novice.md
@@ -1,8 +1,8 @@
-# Learning outcomes for movice programmers
+# Learning outcomes for novice programmers
 _After participating in the workshop, learners will be able to…_
 
-* Summarise some of the ethical concerns around the development and use of genAI.
+* Highlight some of the ethical concerns around the development and use of genAI.
 * Assess the risk of using the output from generative AI in a coding task.
-* Summarise the process through which a large language model is developed and presented to the user.
+* Comprehend the process through which a large language model is developed and presented to the user.
 * Identify how choices made during development influence the suitability of the resulting model for different tasks.
 * Recognise the importance of evaluating the output of an LLM to the success and integrity of research.

--- a/learning-outcomes-novice.md
+++ b/learning-outcomes-novice.md
@@ -3,6 +3,6 @@ _After participating in the workshop, learners will be able to…_
 
 * Highlight some of the ethical concerns around the development and use of genAI.
 * Assess the risk of using the output from generative AI in a coding task.
-* Comprehend the process through which a large language model is developed and presented to the user.
+* Summarise the process through which a large language model is developed and presented to the user.
 * Identify how choices made during development influence the suitability of the resulting model for different tasks.
 * Recognise the importance of evaluating the output of an LLM to the success and integrity of research.


### PR DESCRIPTION
Tried to relate outcomes with action to be done while putting the knowledge in practice. Current two uses of "summarise" may wrongly seem like learners are preparing for exams.